### PR TITLE
Set request_fulluri when using proxy

### DIFF
--- a/lib/HttpClient/FileGetContentsHttpClient.php
+++ b/lib/HttpClient/FileGetContentsHttpClient.php
@@ -82,6 +82,7 @@ class FileGetContentsHttpClient implements HttpClientInterface
 
         if ($this->proxy) {
             $opts['http']['proxy'] = $this->proxy;
+            $opts['http']['request_fulluri'] = true;
         }
 
         // if is relative url


### PR DESCRIPTION
When we try to access an URL through a proxy, it doesn't work (We receive a 400 bad request error) 

We fix this issue by adding request_fullurl option to stream_create_context.
